### PR TITLE
Release v4.0.1 to production

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -65,9 +65,24 @@ To release a new version of the Flutter CLI Utils tool:
 4. **Push to GitHub**
 
    ```bash
+   # If working on a feature branch
    git add .
    git commit -m "chore: release v1.0.0"
-   git push origin main
+   git push origin feature/release-v1.0.0
+   ```
+
+5. **Create and merge pull requests**
+
+   ```bash
+   # If on feature branch, first merge to development
+   gh pr create --base development --head feature/release-v1.0.0 --title "Release v1.0.0" --body "Release version 1.0.0 with updates"
+   gh pr merge --merge --delete-branch
+
+   # Then create PR from development to production
+   gh pr create --base production --head development --title "Release v1.0.0 to production" --body "Release version 1.0.0 with updates"
+
+   # After review, merge to production
+   gh pr merge --merge --delete-branch=false
    ```
 
    > **Note**: The CLI tool is currently distributed as source code on GitHub (not published to pub.dev)

--- a/bricks/flutter_starter_brick/CHANGELOG.md
+++ b/bricks/flutter_starter_brick/CHANGELOG.md
@@ -63,3 +63,8 @@ some files and folders.
 
 # 4.0.0
 - Complete architecture overhaul
+
+# 4.0.1
+- Added freezed generated files (*.freezed.dart) to .gitignore
+- Added claude_scratchpad/ folder to .gitignore for Claude development tracking
+- Added /android/.kotlin/ folder to .gitignore for Android Kotlin metadata

--- a/bricks/flutter_starter_brick/__brick__/l10n.yaml
+++ b/bricks/flutter_starter_brick/__brick__/l10n.yaml
@@ -2,4 +2,3 @@ arb-dir: lib/resources/src/arb
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 nullable-getter: false
-synthetic-package: false

--- a/bricks/flutter_starter_brick/brick.yaml
+++ b/bricks/flutter_starter_brick/brick.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/Haidar0096/fcu/tree/main/bricks/flutter_starter_b
 # The following defines the version and build number for your brick.
 # A version number is three numbers separated by dots, like 1.2.34
 # followed by an optional build number (separated by a +).
-version: 4.0.0
+version: 4.0.1
 
 # The following defines the environment for the current brick.
 # It includes the version of mason that the brick requires.

--- a/lib/src/commands/new_project_command.dart
+++ b/lib/src/commands/new_project_command.dart
@@ -268,6 +268,9 @@ class NewProjectCommand extends Command<int> {
       '',
       '# Claude scratchpad',
       'claude_scratchpad/',
+      '',
+      '# Android Kotlin metadata',
+      '/android/.kotlin/',
     ].join('\n');
     final addToGitIgnoreResult = await Process.run('bash', [
       '-c',

--- a/lib/src/commands/new_project_command.dart
+++ b/lib/src/commands/new_project_command.dart
@@ -264,6 +264,10 @@ class NewProjectCommand extends Command<int> {
       '\n# Generated files',
       '**/dependency_injection.config.dart',
       '**/**.g.dart',
+      '**/**.freezed.dart',
+      '',
+      '# Claude scratchpad',
+      'claude_scratchpad/',
     ].join('\n');
     final addToGitIgnoreResult = await Process.run('bash', [
       '-c',

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.0';
+const packageVersion = '4.0.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cli_utils
 description: A command-line tool that provides useful Flutter utilities.
-version: 4.0.0
+version: 4.0.1
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Release v4.0.1

### Changes
- Added freezed generated files (*.freezed.dart) to .gitignore
- Added claude_scratchpad/ folder to .gitignore for Claude development tracking  
- Added /android/.kotlin/ folder to .gitignore for Android Kotlin metadata
- Updated documentation for release process

### Versions
- Brick version: 4.0.1 (published to BrickHub)
- CLI version: 4.0.1