### PR TITLE
Release flutter_starter_brick v4.0.2 to production

### DIFF
--- a/bricks/flutter_starter_brick/CHANGELOG.md
+++ b/bricks/flutter_starter_brick/CHANGELOG.md
@@ -68,3 +68,9 @@ some files and folders.
 - Added freezed generated files (*.freezed.dart) to .gitignore
 - Added claude_scratchpad/ folder to .gitignore for Claude development tracking
 - Added /android/.kotlin/ folder to .gitignore for Android Kotlin metadata
+
+# 4.0.2
+- Improved random jokes screen UI layout with button docked at bottom
+- Fixed layout overflow issues with long jokes using SingleChildScrollView
+- Simplified error state handling with cleaner conditional rendering
+- Added flutter_launcher_icons package to dev dependencies for app icon generation

--- a/bricks/flutter_starter_brick/__brick__/lib/features/random_jokes/src/ui/random_jokes_screen.dart
+++ b/bricks/flutter_starter_brick/__brick__/lib/features/random_jokes/src/ui/random_jokes_screen.dart
@@ -18,37 +18,40 @@ class RandomJokesScreen extends StatelessWidget {
       );
 
       return RootScreenWidget(
-        body: Column(
-          children: [
-            // Error banner if there's an error
-            if (state is JokesFailed)
-              StatusBannerWidget(
-                type: StatusBannerType.error,
-                message: state.uiFailure.getDisplayText(context),
-                actionText: context.appLocalizations.retry,
-                onAction: () => context.read<JokesCubit>().fetchJoke(),
-              ),
-
-            // Main content
-            Expanded(
-              child: Center(
-                child: switch (state) {
-                  JokesInitial() => fetchButton,
-                  JokesLoading() => const LoaderWidget(),
-                  JokesLoaded() => Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      JokeCard(joke: state.joke),
-                      const Spacing.vertical(SpacingSize.small),
-                      fetchButton,
-                    ],
+        body: state is JokesFailed
+            ? Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  StatusBannerWidget(
+                    type: StatusBannerType.error,
+                    message: state.uiFailure.getDisplayText(context),
+                    actionText: context.appLocalizations.retry,
+                    onAction: () => context.read<JokesCubit>().fetchJoke(),
                   ),
-                  JokesFailed() => const SizedBox.shrink(), // Error handled by banner
-                },
+                ],
+              )
+            : Column(
+                children: [
+                  Expanded(
+                    child: Center(
+                      child: switch (state) {
+                        JokesInitial() => const SizedBox.shrink(),
+                        JokesLoading() => const LoaderWidget(),
+                        JokesLoaded() => SingleChildScrollView(
+                          child: JokeCard(joke: state.joke),
+                        ),
+                        JokesFailed() =>
+                          const SizedBox.shrink(), // Never reached
+                      },
+                    ),
+                  ),
+                  // Button docked at bottom
+                  Padding(
+                    padding: EdgeInsets.all(SpacingSize.medium.value),
+                    child: fetchButton,
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
       );
     },
   );

--- a/bricks/flutter_starter_brick/brick.yaml
+++ b/bricks/flutter_starter_brick/brick.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/Haidar0096/fcu/tree/main/bricks/flutter_starter_b
 # The following defines the version and build number for your brick.
 # A version number is three numbers separated by dots, like 1.2.34
 # followed by an optional build number (separated by a +).
-version: 4.0.1
+version: 4.0.2
 
 # The following defines the environment for the current brick.
 # It includes the version of mason that the brick requires.

--- a/bricks/flutter_starter_brick/hooks/post_gen.dart
+++ b/bricks/flutter_starter_brick/hooks/post_gen.dart
@@ -34,7 +34,8 @@ Future<void> run(HookContext context) async {
         'build_runner:^2.7.1',
         'go_router_builder:^3.0.0',
         'build_verify:^3.1.1',
-        'json_serializable:^6.11.1'
+        'json_serializable:^6.11.1',
+        'flutter_launcher_icons:^0.14.4'
       ],
     ),
   );


### PR DESCRIPTION
## Summary
Release of flutter_starter_brick v4.0.2 to production

## Changes in v4.0.2
- Improved random jokes screen UI layout with button docked at bottom
- Fixed layout overflow issues with long jokes using SingleChildScrollView
- Simplified error state handling with cleaner conditional rendering
- Added flutter_launcher_icons package to dev dependencies for app icon generation

## Release Status
✅ Brick v4.0.2 published to BrickHub
✅ Merged to development via PR #8
✅ Ready for production release

## Type
Brick-only release (CLI version unchanged)