### PR TITLE
Release v4.0.4 to production

### DIFF
--- a/bricks/flutter_starter_brick/CHANGELOG.md
+++ b/bricks/flutter_starter_brick/CHANGELOG.md
@@ -75,6 +75,9 @@ some files and folders.
 - Simplified error state handling with cleaner conditional rendering
 - Added flutter_launcher_icons package to dev dependencies for app icon generation
 
+# 4.0.4
+- Removed version history section from README for cleaner documentation
+
 # 4.0.3
 - Moved ValidateableStateMixin from foundation/ui/widgets to foundation/ui/mixins for better module organization
 - Refactored spacing system with complete 4-unit steps (4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64)

--- a/bricks/flutter_starter_brick/README.md
+++ b/bricks/flutter_starter_brick/README.md
@@ -91,10 +91,6 @@ Every generated project includes a comprehensive `CLAUDE.md` file that documents
 - Typography and theming system
 - State management patterns
 
-## Version History
-
-**4.0.0** - Complete architecture overhaul with foundation layer, improved patterns, and comprehensive documentation
-
 ## Support Me
 
 It is really hard and time-consuming to maintain and update open-source projects, so if you like my

--- a/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/overlays/src/alert_dialog.dart
+++ b/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/overlays/src/alert_dialog.dart
@@ -32,7 +32,10 @@ Future<void> showAlertDialog({
     content: Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (icon != null) ...[icon, SizedBox(height: SpacingSize.spacing24.value)],
+        if (icon != null) ...[
+          icon,
+          SizedBox(height: SpacingSize.spacing24.value),
+        ],
         Text(
           title,
           style: context.themeData.textTheme.headlineSmall,

--- a/bricks/flutter_starter_brick/brick.yaml
+++ b/bricks/flutter_starter_brick/brick.yaml
@@ -9,7 +9,7 @@ repository: https://github.com/Haidar0096/fcu/tree/main/bricks/flutter_starter_b
 # The following defines the version and build number for your brick.
 # A version number is three numbers separated by dots, like 1.2.34
 # followed by an optional build number (separated by a +).
-version: 4.0.3
+version: 4.0.4
 
 # The following defines the environment for the current brick.
 # It includes the version of mason that the brick requires.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '4.0.3';
+const packageVersion = '4.0.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_cli_utils
 description: A command-line tool that provides useful Flutter utilities.
-version: 4.0.3
+version: 4.0.4
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Release v4.0.4 to Production

### Changes
- Update brick version to 4.0.4
- Update CLI version to 4.0.4
- Remove version history section from brick README for cleaner documentation
- Update brick CHANGELOG with 4.0.4 entry

### Release Status
- [x] All changes committed
- [x] Merged to development branch
- [x] Brick published to BrickHub
- [x] All checks passed

Ready for production deployment.