### PR TITLE
Release brick 4.8.1 — the two bugs a 4.8.0 generated app hits on its own checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,8 @@ Audience: Flutter CLI Utils contributors and adopters; public project setup and 
 
 ## Getting Started 🚀
 
-If the CLI application is available on [pub.dev](https://pub.dev), activate globally via:
-
-```sh
-dart pub global activate flutter_cli_utils
-```
-
-Or locally via:
+The CLI application is distributed as source on GitHub, not on
+[pub.dev](https://pub.dev), so activate it from a local clone:
 
 - Clone this repository
 - Run the following script from the project root to activate the CLI application globally:
@@ -31,5 +26,5 @@ $ fcu --help
 
 Example:
 ```sh
-fcu create --desc "My starter app" --org "com.my_startup" --name "starter_app" --ios-lang swift --android-lang "kotlin" --template app --target-platforms "android,ios" --output-directory "starter_app" --overwrite-existing-directory --use-starter-brick --initialize-git-repo
+fcu create --desc "My starter app" --org "com.my_startup" --name "starter_app" --dev-name "developer" --ios-lang swift --android-lang "kotlin" --template app --target-platforms "android,ios" --output-directory "starter_app" --overwrite-existing-directory --use-starter-brick --initialize-git-repo
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -127,6 +127,9 @@ Before releasing either component:
 - [ ] Version bumped appropriately (follow [Semantic Versioning](https://semver.org/))
 - [ ] No hardcoded paths or development configurations
 - [ ] Brick bundle updated if brick was modified
+- [ ] Proof app generated from the LOCAL brick (`mason add --path`, not
+      BrickHub) and every command in its `.github/workflows/checks.yml`
+      run green in that app before publishing
 
 ## Version Synchronization
 

--- a/bricks/flutter_starter_brick/CHANGELOG.md
+++ b/bricks/flutter_starter_brick/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 4.8.1
+Release date: TBD. A patch: two bugs a 4.8.0 generated app hits on its own
+checks workflow. Nothing is added or removed, and the fcu CLI stays 4.4.2.
+- Fixed: the `no_transport_imports_in_ui` architecture rule reported the
+  starter's own `foundation/ui/models/src/ui_network_failure.dart`, so
+  `dart analyze` failed in every generated app. Brick 4.7.2 widened the
+  rule's file test from `foundation/ui/src/ui/` to the whole
+  `foundation/ui/` subtree, which swept the UI models folder in. The rule
+  guards WIDGET files; `foundation/ui/models/` is a UI model home, not a
+  widget folder, and a UI model is built at the Bloc boundary from the
+  transport type it displays. The folder is now excluded by the rule
+  itself, with no ignore comment and no file move. Two tests cover the
+  split: a widget under `foundation/ui/widgets/` importing networking is
+  still reported, and the UI model is not.
+- Fixed: the URL-strategy platform-divergence family shipped without its
+  `url_strategy_io.dart` sibling, so `dart run tool/check_structure_io.dart`
+  failed in every generated app. The no-op `_io` file is now present and the
+  facade carries its `if (dart.library.io)` arm, matching the shape of the
+  template's five other conditional families.
+
 # 4.8.0
 Release date: 2026-08-31. A minor release: the starter moves to Flutter
 3.47.2 and clears every analyzer finding that version raised.

--- a/bricks/flutter_starter_brick/CHANGELOG.md
+++ b/bricks/flutter_starter_brick/CHANGELOG.md
@@ -4,7 +4,7 @@ checks workflow. Nothing is added or removed, and the fcu CLI stays 4.4.2.
 - Fixed: the `no_transport_imports_in_ui` architecture rule reported the
   starter's own `foundation/ui/models/src/ui_network_failure.dart`, so
   `dart analyze` failed in every generated app. Brick 4.7.2 widened the
-  rule's file test from `foundation/ui/src/ui/` to the whole
+  rule's file test from any path containing `/src/ui/` to the whole
   `foundation/ui/` subtree, which swept the UI models folder in. The rule
   guards WIDGET files; `foundation/ui/models/` is a UI model home, not a
   widget folder, and a UI model is built at the Bloc boundary from the

--- a/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/navigation/src/url_strategy.dart
+++ b/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/navigation/src/url_strategy.dart
@@ -1,2 +1,3 @@
 export 'url_strategy_stub.dart'
+    if (dart.library.io) 'url_strategy_io.dart'
     if (dart.library.js_interop) 'url_strategy_web.dart';

--- a/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/navigation/src/url_strategy_io.dart
+++ b/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/navigation/src/url_strategy_io.dart
@@ -1,0 +1,1 @@
+void configureUrlStrategy() {}

--- a/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/README.md
+++ b/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/README.md
@@ -95,7 +95,7 @@ Every diagnostic below has `WARNING` severity.
 - `no_backend_url_literals`: backend URL literals cannot live anywhere in Dart source.
 - `no_route_path_literals`: route path literals stay in the `RoutePath` family.
 - `no_dto_in_ui_or_bloc_state`: widgets and Bloc state cannot name a `*Dto` type.
-- `no_transport_imports_in_ui`: UI files cannot import API, networking, transport, or `NetworkFailure` code.
+- `no_transport_imports_in_ui`: widget files cannot import API, networking, transport, or `NetworkFailure` code; `foundation/ui/models/` is a UI model home, not a widget folder, and is excluded because a UI model is built at the Bloc boundary from the transport type it displays.
 - `no_framework_colors_in_ui`: UI cannot use `Colors.*`, except `Colors.transparent`.
 - `no_snackbar_outside_banner`: `SnackBar` and `ScaffoldMessenger` stay in shared banner code.
 - `no_flutter_form`: Flutter's `Form` widget is replaced by the project form helper.

--- a/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/lib/src/rules/no_transport_imports_in_ui_rule.dart
+++ b/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/lib/src/rules/no_transport_imports_in_ui_rule.dart
@@ -1,4 +1,9 @@
 /// Stops API and transport imports at the Bloc boundary.
+///
+/// The rule guards WIDGET files. `foundation/ui/models/` is a UI MODEL home,
+/// not a widget folder: a UI model is the display-side twin of a transport
+/// type, built at the Bloc boundary, so it must name the transport type it
+/// converts from and is excluded from this rule.
 library;
 
 import 'package:analyzer/analysis_rule/analysis_rule.dart';
@@ -23,6 +28,10 @@ bool _isUiFilePath(String filePath) {
   if (segments.length >= 2 &&
       segments[0] == 'foundation' &&
       segments[1] == 'ui') {
+    // `foundation/ui/models/` holds UI models, not widgets. A UI model is
+    // created at the Bloc boundary from the transport type it displays, so it
+    // names that type by design.
+    if (segments.length >= 3 && segments[2] == 'models') return false;
     return true;
   }
   if (segments.isEmpty || segments.first != 'features') return false;

--- a/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/test/new_architecture_rules_test.dart
+++ b/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/test/new_architecture_rules_test.dart
@@ -477,6 +477,34 @@ class NoTransportImportsInUiRuleTest extends AnalysisRuleTest {
     newFile(path, source);
     await assertNoDiagnosticsInFile(path);
   }
+
+  Future<void> test_networkingImportInFoundationUiWidget_reports() async {
+    newFile(
+      '$testPackageLibPath/foundation/networking/networking.dart',
+      'class NetworkFailure {}',
+    );
+    const source =
+        "import 'package:test/foundation/networking/networking.dart';\n"
+        'NetworkFailure? failure;\n';
+    final path =
+        '$testPackageLibPath/foundation/ui/widgets/src/status_banner.dart';
+    newFile(path, source);
+    await assertDiagnosticsInFile(path, [lint(0, source.indexOf('\n'))]);
+  }
+
+  Future<void> test_networkingImportInFoundationUiModel_isQuiet() async {
+    newFile(
+      '$testPackageLibPath/foundation/networking/networking.dart',
+      'class NetworkFailure {}',
+    );
+    const source =
+        "import 'package:test/foundation/networking/networking.dart';\n"
+        'NetworkFailure? failure;\n';
+    final path =
+        '$testPackageLibPath/foundation/ui/models/src/ui_network_failure.dart';
+    newFile(path, source);
+    await assertNoDiagnosticsInFile(path);
+  }
 }
 
 @reflectiveTest

--- a/bricks/flutter_starter_brick/brick.yaml
+++ b/bricks/flutter_starter_brick/brick.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/Haidar0096/fcu/tree/production/bricks/flutter_sta
 # The following defines the version and build number for your brick.
 # A version number is three numbers separated by dots, like 1.2.34
 # followed by an optional build number (separated by a +).
-version: 4.8.0
+version: 4.8.1
 
 # The following defines the environment for the current brick.
 # It includes the version of mason that the brick requires.


### PR DESCRIPTION
Brick 4.8.1. Two bugs that make a 4.8.0 generated app fail its own `checks.yml`, plus four documentation claims that were false. The fcu CLI is unchanged at 4.4.2.

## Fix 1 — `no_transport_imports_in_ui` swept the UI models folder in

Brick 4.7.2 widened the rule's file test from `/src/ui/` to the whole `foundation/ui/` subtree. That made every file under `foundation/ui/` a UI file, including `foundation/ui/models/src/ui_network_failure.dart`, which imports `foundation/networking/networking.dart`. `dart analyze` therefore failed in every generated app:

```
warning - lib/foundation/ui/models/src/ui_network_failure.dart:1:1 - UI files must not import API, transport, or NetworkFailure code. Expose UI-shaped state from the Bloc instead. - no_transport_imports_in_ui
```

The rule guards WIDGET files. `foundation/ui/models/` is a UI model home, not a widget folder: `UiNetworkFailure` is the display-side twin of `NetworkFailure`, built by the bloc at its boundary (`jokes_cubit.dart`) and only displayed by widgets, which is the skill's model pattern (`models.md` rules 1 and 13 — conversion at the bloc, never in a widget). The folder is now excluded by the rule itself. No ignore comment, no file move.

The `features/**/src/ui/`, `shared/ui` and the rest of the `foundation/ui/` arms are untouched.

## Fix 2 — the url_strategy family was missing its `_io` file

`foundation/ui/navigation/src/` held `url_strategy.dart` (facade, `js_interop` arm only), `url_strategy_stub.dart` and `url_strategy_web.dart`, but no `url_strategy_io.dart`. `structure.md` rule 14 and the starter's own `tool/check_structure_io.dart` require facade + `_io` + `_web` + `_stub`, so the structure gate failed in every generated app:

```
Structure check failed with 1 violation(s):
- lib/foundation/ui/navigation/src/url_strategy_io.dart — structure.md rule 14: conditional files need facade, _io, _web, and _stub siblings
```

Adds the no-op `void configureUrlStrategy() {}`, matching the signature the `_stub` and `_web` siblings expose, and the `if (dart.library.io)` arm on the facade, shaped like the template's five other conditional families.

## Documentation

- `bricks/flutter_starter_brick/brick.yaml` — version 4.8.0 to 4.8.1.
- `bricks/flutter_starter_brick/CHANGELOG.md` — a 4.8.1 entry saying what this release fixes. The 4.8.0 claim that every analyzer finding was cleared is left as written. Release date is `TBD`, the documented value while the date is unknown (RELEASE.md step 4).
- `RELEASE.md` — the pre-release checklist never generated an app and ran that app's own checks, although the 4.7.1, 4.7.2 and now 4.8.1 entries all record a proof app as what found their bugs. One checklist step added, naming the local brick.
- `README.md` — `dart pub global activate flutter_cli_utils` cannot work: the root pubspec is `publish_to: none` and RELEASE.md line 118 says the CLI is not on pub.dev. Replaced with the `bash scripts/activate.sh` install the repo actually documents. The `fcu create` example also gained `--dev-name`, without which `--use-starter-brick` still prompts.
- `packages/architecture_lint_rules/README.md` — the rule line now states the exception.

Nothing was changed in the root `pubspec.yaml` or `lib/src/version.dart`: RELEASE.md scopes a brick release to the brick section's version and changelog steps plus CLI-section steps 1 and 5 to 8.

## Proof

Tests:

| Suite | Collected | Passed | Failed |
|---|---|---|---|
| fcu root, `dart test` | 4 | 4 | 0 |
| `architecture_lint_rules`, `dart test` | 115 | 115 | 0 |

The two new rule tests fail on the old rule body and pass on the new one.

A proof app was generated from the LOCAL brick with `mason add flutter_starter_brick --path <repo>/bricks/flutter_starter_brick`, so `mason.yaml` resolved a `path:` brick and not BrickHub. Every command in the generated `.github/workflows/checks.yml` was then run in it, in order, and every one exited 0: `flutter pub get`, `flutter gen-l10n`, `dart run build_runner build --delete-conflicting-outputs`, `dart format --output=none --set-exit-if-changed lib test` (202 files, 0 changed), `flutter analyze`, `dart analyze`, `dart run tool/check_structure_io.dart`, `flutter test` (4 passed), and the workflow's named build step `flutter build bundle --dart-define-from-file=env/development.json`. The workflow comment says a web project adds a web build, so `flutter build web --dart-define-from-file=env/development.json` was also run green.

```
$ dart analyze
Analyzing fcu_proof_check...
No issues found!

$ dart run tool/check_structure_io.dart
Structure check passed.
```

The rule still bites. Adding `import 'package:fcu_proof_check/foundation/networking/networking.dart';` to `lib/foundation/ui/widgets/src/loader_widget.dart` reports it, and removing the line returns the app to green:

```
warning - lib/foundation/ui/widgets/src/loader_widget.dart:1:1 - UI files must not import API, transport, or NetworkFailure code. Expose UI-shaped state from the Bloc instead. - no_transport_imports_in_ui
warning - lib/foundation/ui/widgets/src/loader_widget.dart:1:8 - Unused import: 'package:fcu_proof_check/foundation/networking/networking.dart'. Try removing the import directive. - unused_import
```

Both bugs were also reproduced in the proof app by restoring the 4.8.0 state of each file, confirming the fixes are what clear them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MZHfmsXQet7nTxSqNHMQw