### PR TITLE
Set the brick 4.8.1 release date

### DIFF
--- a/bricks/flutter_starter_brick/CHANGELOG.md
+++ b/bricks/flutter_starter_brick/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 4.8.1
-Release date: TBD. A patch: two bugs a 4.8.0 generated app hits on its own
+Release date: 2026-09-06. A patch: two bugs a 4.8.0 generated app hits on its own
 checks workflow. Nothing is added or removed, and the fcu CLI stays 4.4.2.
 - Fixed: the `no_transport_imports_in_ui` architecture rule reported the
   starter's own `foundation/ui/models/src/ui_network_failure.dart`, so


### PR DESCRIPTION
Release day for brick 4.8.1. RELEASE.md step 4 says the changelog entry carries `TBD` while the release date is unknown and the exact date once it is known, and that on release day a branch updates the date even if that is the only change. This is that branch.

`bricks/flutter_starter_brick/CHANGELOG.md` — the 4.8.1 entry's `Release date: TBD.` becomes `Release date: 2026-09-06.`, in the `Release date: YYYY-MM-DD.` form the 4.7.0, 4.7.1, 4.7.2 and 4.8.0 entries use.

One line changed. No code, no version, no other entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MZHfmsXQet7nTxSqNHMQw