### PR TITLE
Release brick v4.8.1 to production

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,8 @@ Audience: Flutter CLI Utils contributors and adopters; public project setup and 
 
 ## Getting Started 🚀
 
-If the CLI application is available on [pub.dev](https://pub.dev), activate globally via:
-
-```sh
-dart pub global activate flutter_cli_utils
-```
-
-Or locally via:
+The CLI application is distributed as source on GitHub, not on
+[pub.dev](https://pub.dev), so activate it from a local clone:
 
 - Clone this repository
 - Run the following script from the project root to activate the CLI application globally:
@@ -31,5 +26,5 @@ $ fcu --help
 
 Example:
 ```sh
-fcu create --desc "My starter app" --org "com.my_startup" --name "starter_app" --ios-lang swift --android-lang "kotlin" --template app --target-platforms "android,ios" --output-directory "starter_app" --overwrite-existing-directory --use-starter-brick --initialize-git-repo
+fcu create --desc "My starter app" --org "com.my_startup" --name "starter_app" --dev-name "developer" --ios-lang swift --android-lang "kotlin" --template app --target-platforms "android,ios" --output-directory "starter_app" --overwrite-existing-directory --use-starter-brick --initialize-git-repo
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -127,6 +127,9 @@ Before releasing either component:
 - [ ] Version bumped appropriately (follow [Semantic Versioning](https://semver.org/))
 - [ ] No hardcoded paths or development configurations
 - [ ] Brick bundle updated if brick was modified
+- [ ] Proof app generated from the LOCAL brick (`mason add --path`, not
+      BrickHub) and every command in its `.github/workflows/checks.yml`
+      run green in that app before publishing
 
 ## Version Synchronization
 

--- a/bricks/flutter_starter_brick/CHANGELOG.md
+++ b/bricks/flutter_starter_brick/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 4.8.1
-Release date: TBD. A patch: two bugs a 4.8.0 generated app hits on its own
+Release date: 2026-09-06. A patch: two bugs a 4.8.0 generated app hits on its own
 checks workflow. Nothing is added or removed, and the fcu CLI stays 4.4.2.
 - Fixed: the `no_transport_imports_in_ui` architecture rule reported the
   starter's own `foundation/ui/models/src/ui_network_failure.dart`, so

--- a/bricks/flutter_starter_brick/CHANGELOG.md
+++ b/bricks/flutter_starter_brick/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 4.8.1
+Release date: TBD. A patch: two bugs a 4.8.0 generated app hits on its own
+checks workflow. Nothing is added or removed, and the fcu CLI stays 4.4.2.
+- Fixed: the `no_transport_imports_in_ui` architecture rule reported the
+  starter's own `foundation/ui/models/src/ui_network_failure.dart`, so
+  `dart analyze` failed in every generated app. Brick 4.7.2 widened the
+  rule's file test from any path containing `/src/ui/` to the whole
+  `foundation/ui/` subtree, which swept the UI models folder in. The rule
+  guards WIDGET files; `foundation/ui/models/` is a UI model home, not a
+  widget folder, and a UI model is built at the Bloc boundary from the
+  transport type it displays. The folder is now excluded by the rule
+  itself, with no ignore comment and no file move. Two tests cover the
+  split: a widget under `foundation/ui/widgets/` importing networking is
+  still reported, and the UI model is not.
+- Fixed: the URL-strategy platform-divergence family shipped without its
+  `url_strategy_io.dart` sibling, so `dart run tool/check_structure_io.dart`
+  failed in every generated app. The no-op `_io` file is now present and the
+  facade carries its `if (dart.library.io)` arm, matching the shape of the
+  template's five other conditional families.
+
 # 4.8.0
 Release date: 2026-08-31. A minor release: the starter moves to Flutter
 3.47.2 and clears every analyzer finding that version raised.

--- a/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/navigation/src/url_strategy.dart
+++ b/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/navigation/src/url_strategy.dart
@@ -1,2 +1,3 @@
 export 'url_strategy_stub.dart'
+    if (dart.library.io) 'url_strategy_io.dart'
     if (dart.library.js_interop) 'url_strategy_web.dart';

--- a/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/navigation/src/url_strategy_io.dart
+++ b/bricks/flutter_starter_brick/__brick__/lib/foundation/ui/navigation/src/url_strategy_io.dart
@@ -1,0 +1,1 @@
+void configureUrlStrategy() {}

--- a/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/README.md
+++ b/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/README.md
@@ -95,7 +95,7 @@ Every diagnostic below has `WARNING` severity.
 - `no_backend_url_literals`: backend URL literals cannot live anywhere in Dart source.
 - `no_route_path_literals`: route path literals stay in the `RoutePath` family.
 - `no_dto_in_ui_or_bloc_state`: widgets and Bloc state cannot name a `*Dto` type.
-- `no_transport_imports_in_ui`: UI files cannot import API, networking, transport, or `NetworkFailure` code.
+- `no_transport_imports_in_ui`: widget files cannot import API, networking, transport, or `NetworkFailure` code; `foundation/ui/models/` is a UI model home, not a widget folder, and is excluded because a UI model is built at the Bloc boundary from the transport type it displays.
 - `no_framework_colors_in_ui`: UI cannot use `Colors.*`, except `Colors.transparent`.
 - `no_snackbar_outside_banner`: `SnackBar` and `ScaffoldMessenger` stay in shared banner code.
 - `no_flutter_form`: Flutter's `Form` widget is replaced by the project form helper.

--- a/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/lib/src/rules/no_transport_imports_in_ui_rule.dart
+++ b/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/lib/src/rules/no_transport_imports_in_ui_rule.dart
@@ -1,4 +1,9 @@
 /// Stops API and transport imports at the Bloc boundary.
+///
+/// The rule guards WIDGET files. `foundation/ui/models/` is a UI MODEL home,
+/// not a widget folder: a UI model is the display-side twin of a transport
+/// type, built at the Bloc boundary, so it must name the transport type it
+/// converts from and is excluded from this rule.
 library;
 
 import 'package:analyzer/analysis_rule/analysis_rule.dart';
@@ -23,6 +28,10 @@ bool _isUiFilePath(String filePath) {
   if (segments.length >= 2 &&
       segments[0] == 'foundation' &&
       segments[1] == 'ui') {
+    // `foundation/ui/models/` holds UI models, not widgets. A UI model is
+    // created at the Bloc boundary from the transport type it displays, so it
+    // names that type by design.
+    if (segments.length >= 3 && segments[2] == 'models') return false;
     return true;
   }
   if (segments.isEmpty || segments.first != 'features') return false;

--- a/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/test/new_architecture_rules_test.dart
+++ b/bricks/flutter_starter_brick/__brick__/packages/architecture_lint_rules/test/new_architecture_rules_test.dart
@@ -477,6 +477,34 @@ class NoTransportImportsInUiRuleTest extends AnalysisRuleTest {
     newFile(path, source);
     await assertNoDiagnosticsInFile(path);
   }
+
+  Future<void> test_networkingImportInFoundationUiWidget_reports() async {
+    newFile(
+      '$testPackageLibPath/foundation/networking/networking.dart',
+      'class NetworkFailure {}',
+    );
+    const source =
+        "import 'package:test/foundation/networking/networking.dart';\n"
+        'NetworkFailure? failure;\n';
+    final path =
+        '$testPackageLibPath/foundation/ui/widgets/src/status_banner.dart';
+    newFile(path, source);
+    await assertDiagnosticsInFile(path, [lint(0, source.indexOf('\n'))]);
+  }
+
+  Future<void> test_networkingImportInFoundationUiModel_isQuiet() async {
+    newFile(
+      '$testPackageLibPath/foundation/networking/networking.dart',
+      'class NetworkFailure {}',
+    );
+    const source =
+        "import 'package:test/foundation/networking/networking.dart';\n"
+        'NetworkFailure? failure;\n';
+    final path =
+        '$testPackageLibPath/foundation/ui/models/src/ui_network_failure.dart';
+    newFile(path, source);
+    await assertNoDiagnosticsInFile(path);
+  }
 }
 
 @reflectiveTest

--- a/bricks/flutter_starter_brick/brick.yaml
+++ b/bricks/flutter_starter_brick/brick.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/Haidar0096/fcu/tree/production/bricks/flutter_sta
 # The following defines the version and build number for your brick.
 # A version number is three numbers separated by dots, like 1.2.34
 # followed by an optional build number (separated by a +).
-version: 4.8.0
+version: 4.8.1
 
 # The following defines the environment for the current brick.
 # It includes the version of mason that the brick requires.


### PR DESCRIPTION
Brick 4.8.1 to production. A patch release: two bugs that make a 4.8.0 generated app fail its own `.github/workflows/checks.yml`. Nothing is added or removed, and the fcu CLI stays 4.4.2.

What rides this merge, both already squash-merged into `development`:

- #32 — the two template fixes, the `brick.yaml` bump from 4.8.0 to 4.8.1, the 4.8.1 changelog entry, and four documentation corrections in `RELEASE.md`, `README.md` and the architecture lint rules README.
- #33 — the 4.8.1 changelog entry's release date, `TBD` to 2026-09-06, per RELEASE.md step 4.

The two fixes:

1. `no_transport_imports_in_ui` reported the starter's own `foundation/ui/models/src/ui_network_failure.dart`, so `dart analyze` failed in every generated app. The rule guards widget files; the UI models folder is now excluded by the rule itself.
2. The URL-strategy conditional family shipped without its `url_strategy_io.dart` sibling, so `dart run tool/check_structure_io.dart` failed in every generated app. The no-op `_io` file is present and the facade carries its `if (dart.library.io)` arm.

Merged on the explicit human go that RELEASE.md step 6 requires. After this merge: tag `v4.8.1` on `production`, publish the brick to BrickHub, and cut the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MZHfmsXQet7nTxSqNHMQw