### PR TITLE
Release page fixes: brick release scope and local proof route

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -91,7 +91,7 @@ the flow this repo uses.
    CLI release `vX.Y.Z` would collide with the brick tag of that number.
 
    **The brick section above carries no git flow of its own, so a brick release
-   uses steps 1 and 5 to 8 of this section — and takes the brick tag.**
+   uses steps 1, 4 and 5 to 8 of this section — and takes the brick tag.**
 
    ```bash
    git switch production && git pull
@@ -129,7 +129,36 @@ Before releasing either component:
 - [ ] Brick bundle updated if brick was modified
 - [ ] Proof app generated from the LOCAL brick (`mason add --path`, not
       BrickHub) and every command in its `.github/workflows/checks.yml`
-      run green in that app before publishing
+      run green in that app before publishing. `fcu create` has no
+      local-brick flag — it always runs `mason add flutter_starter_brick`
+      against BrickHub — so the local proof takes two stages: create the
+      empty Flutter app, then point Mason at the working tree.
+
+      ```bash
+      # Stage 1 — the same answers you would give `fcu create`.
+      flutter create --empty --project-name my_proof --org com.example \
+        -t app --platforms android,ios,web,windows,linux,macos my_proof
+      cd my_proof
+
+      # Stage 2 — the brick from this working tree, not BrickHub.
+      mason init
+      mason add flutter_starter_brick --path <repo>/bricks/flutter_starter_brick
+      mason get
+
+      # The pre-gen hook replaces `lib/` only in fresh `flutter create`
+      # output. It requires `.metadata`, `pubspec.yaml` and `lib/main.dart`
+      # in the project root, plus a sentinel naming the same token that
+      # `mason make` is given. The sentinel holds three newline-terminated
+      # lines: the literal version marker, the token, and the
+      # symlink-resolved absolute project root. The hook deletes it.
+      TOKEN=$(openssl rand -hex 32)
+      printf '%s\n%s\n%s\n' fcu-fresh-flutter-output-v1 "$TOKEN" "$(pwd -P)" \
+        > fcu_fresh_flutter_output.sentinel
+
+      mason make flutter_starter_brick --on-conflict overwrite \
+        --proj_name my_proof --proj_desc 'A proof app' --org_name com.example \
+        --dev_name developer --fresh_output_token "$TOKEN"
+      ```
 
 ## Version Synchronization
 


### PR DESCRIPTION
Two claims on `RELEASE.md` that the brick 4.8.1 release proved wrong. Documentation only: nothing under `__brick__` changes, so there is no version bump, no changelog entry, no tag and no publish.

## Fix 1 — a brick release also uses step 4

Step 7 said a brick release uses "steps 1 and 5 to 8 of this section". That omits step 4, which is the only place the changelog-and-release-date rule lives, including the rule that on release day a branch updates the date even if that is the only change. The 4.8.1 release needed exactly that branch, so the scope sentence was wrong as written.

Old:

> **The brick section above carries no git flow of its own, so a brick release
> uses steps 1 and 5 to 8 of this section — and takes the brick tag.**

New:

> **The brick section above carries no git flow of its own, so a brick release
> uses steps 1, 4 and 5 to 8 of this section — and takes the brick tag.**

## Fix 2 — the local proof route

The pre-release checklist named `mason add --path` but not a route that works. `fcu create` has no local-brick flag: `_runStarterBrick` in `lib/src/commands/new_project_command.dart` runs `mason add flutter_starter_brick` with no path argument, so it always resolves from BrickHub and cannot prove an unpublished brick.

The checklist item now carries the two-stage route, `flutter create --empty` followed by Mason pointed at the working tree, and states what the pre-gen hook requires before it will replace `lib/`. Those requirements are read from `bricks/flutter_starter_brick/hooks/pre_gen.dart` and from `_writeFreshOutputSentinel` in the CLI: `.metadata`, `pubspec.yaml` and `lib/main.dart` in the project root, plus `fcu_fresh_flutter_output.sentinel` holding three newline-terminated lines, the literal `fcu-fresh-flutter-output-v1`, the same token passed to `mason make --fresh_output_token`, and the symlink-resolved absolute project root. `--on-conflict overwrite` is included, without which the make stops on the files `flutter create` already wrote.

## Proof

The published brick 4.8.1 was generated with `fcu create --use-starter-brick` and `mason-lock.json` in the generated app reads `{"bricks":{"flutter_starter_brick":"4.8.1"}}`. Every command of that app's `.github/workflows/checks.yml` was run in order and all exited 0, including the web build the workflow's own comment calls for.

```
$ dart analyze
Analyzing fcu_published_check...
No issues found!

$ dart run tool/check_structure_io.dart
Structure check passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MZHfmsXQet7nTxSqNHMQw